### PR TITLE
Dev

### DIFF
--- a/Omni-Utils/API/OmniUtilsAPI.cs
+++ b/Omni-Utils/API/OmniUtilsAPI.cs
@@ -9,6 +9,14 @@ namespace Omni_Utils.API
 {
     public static class OmniUtilsAPI
     {
+    
+        public static string MakeUnitNameReadable(string unit)
+        {
+            string output = string.Empty; //output = ""
+            string[] thing = unit.Split('-'); //thing = ["HOTEL", "09"]
+            output += $"nato_{unit[0]} {thing[1]}"; //output = "nato_H 09"
+            return output;
+        }
         public static void SetNextMtfWave(CustomSquad newsquad)
         {
             OmniUtilsPlugin.NextWaveMtf = newsquad;

--- a/Omni-Utils/Commands/QOL/RoleNameCmd.cs
+++ b/Omni-Utils/Commands/QOL/RoleNameCmd.cs
@@ -22,7 +22,7 @@ namespace Omni_Utils.Commands.QOL
             {
                 p.SetPlayerCustomInfoAndRoleName(p.GetCustomInfo(),name);
             }
-            response = $"Added custom info {name} to {list.Count()} players.";
+            response = $"Added rolename {name} to {list.Count()} players.";
             return true;
         }
 

--- a/Omni-Utils/Configs/CustomTerminationAnnouncementConfig.cs
+++ b/Omni-Utils/Configs/CustomTerminationAnnouncementConfig.cs
@@ -13,6 +13,11 @@ namespace Omni_Utils.Configs
     {
         [Description("Whether this feature set is enabled")]
         public bool IsEnabled { get; set; } = true;
+        [Description("The cassie announcement when a subject dies without a valid attacker (attacker doesn't exist)")]
+        public CustomAnnouncement FallbackTerminationAnnouncement { get; set; } = new CustomAnnouncement { 
+            Words= "%subject% terminated . termination cause unspecified",
+            Translation="%subject% terminated. Termination cause unspecified."
+        };
         public Dictionary<OverallRoleType, CustomAnnouncement> ScpCassieString { get; set; } = new Dictionary<OverallRoleType, CustomAnnouncement>()
         {
             {new OverallRoleType{RoleId=(sbyte)RoleTypeId.Scp049,
@@ -65,11 +70,12 @@ namespace Omni_Utils.Configs
             { new OverallRoleType{RoleId=20,RoleType=RoleVersion.BaseGameRole},
                 "goi_chaos_insurgency" },
         };
+        [Description("%division% is the killer's UnitName, or 'UNKNOWN' if unavailable. %subject% is the name of the victim as defined in scp_cassie_string.")]
         public Dictionary<string, CustomAnnouncement> ScpTerminationCassieAnnouncements { get; set; } = new Dictionary<string, CustomAnnouncement>
         {
             {"goi_unusual_incidents_unit",
                 new CustomAnnouncement{Words="%subject% terminated by the jam_1_3 un- use jam_1_2 u all pitch_1 In Jam_15_3 Sigma dids .g4 unit",
-                Translation="%subject% terminated by the Unusual Incidents Unit"}
+                Translation="%subject% terminated by the Unusual Incidents Unit."}
             },
             { "goi_chaosinsurgency" ,
                 new CustomAnnouncement{Words="%subject% terminated by chaosinsurgency" ,
@@ -80,12 +86,12 @@ namespace Omni_Utils.Configs
                     Translation="%subject% terminated by unknown military personnel." }
             },
             { "mtf_epsilon11",
-                new CustomAnnouncement{Words="%subject% terminated by mtfunit epsilon 11 designated ninetailedfox",
-                    Translation="%subject% terminated by Mobile Task Force Unit Epsilon-11 designated 'Nine-Tailed Fox'."}
+                new CustomAnnouncement{Words="%subject% terminated by mtfunit epsilon 11 division %division%",
+                    Translation="%subject% terminated by Mobile Task Force Unit Epsilon-11, division %division%."}
             },
             { "mtf_facsec",
-                new CustomAnnouncement{Words="%subject% terminated by security personnel",
-                    Translation="%subject% terminated by Security Personnel."}
+                new CustomAnnouncement{Words="%subject% containedsuccessfully . containmentunit %division%",
+                    Translation="%subject% contained successfully. Containment unit: %division%."}
             },
             { "civil_science" ,
                 new CustomAnnouncement{Words="%subject% terminated by science personnel" ,

--- a/Omni-Utils/Configs/CustomTerminationAnnouncementConfig.cs
+++ b/Omni-Utils/Configs/CustomTerminationAnnouncementConfig.cs
@@ -90,16 +90,16 @@ namespace Omni_Utils.Configs
                     Translation="%subject% terminated by Mobile Task Force Unit Epsilon-11, division %division%."}
             },
             { "mtf_facsec",
-                new CustomAnnouncement{Words="%subject% containedsuccessfully . containmentunit %division%",
+                new CustomAnnouncement{Words="%subject% containedsuccessfully containmentunit %division%",
                     Translation="%subject% contained successfully. Containment unit: %division%."}
             },
             { "civil_science" ,
                 new CustomAnnouncement{Words="%subject% terminated by science personnel" ,
-                    Translation="%subject% terminated by science personnel." }
+                    Translation="%subject% terminated by Science Personnel." }
             },
             { "civil_classd" ,
                 new CustomAnnouncement{Words="%subject% terminated by classd personnel",
-                    Translation="%subject% terminated by Class-D personnel." }
+                    Translation="%subject% terminated by Class-D Personnel." }
             }
         };
     }

--- a/Omni-Utils/EventHandlers/CustomSquadEventHandlers.cs
+++ b/Omni-Utils/EventHandlers/CustomSquadEventHandlers.cs
@@ -9,10 +9,12 @@ using Exiled.Events.EventArgs.Cassie;
 using Exiled.Events.EventArgs.Map;
 using Exiled.Events.EventArgs.Server;
 using MEC;
+using Omni_Utils.API;
 using Omni_Utils.Commands;
 using OmniCommonLibrary;
 using PlayerRoles;
 using Respawning.NamingRules;
+using Omni_Utils;
 
 namespace Omni_Utils.EventHandlers
 {
@@ -44,7 +46,6 @@ namespace Omni_Utils.EventHandlers
                 return;
             }
             Log.Debug("Announcing CHAOS ENTRANCE: Custom Squad Detected");
-            CustomSquad customSquad = OmniUtilsPlugin.NextWaveCi;
             e.IsAllowed = false;
 
         }
@@ -109,7 +110,7 @@ namespace Omni_Utils.EventHandlers
                             e.Players.Remove(player);
                             Log.Info($"Spawned {player} for {customSquad.SquadName}");
                         }
-                        if(customSquad.UseCassieAnnouncement)
+                        if (customSquad.UseCassieAnnouncement)
                         {
                             string announcement = customSquad.EntranceAnnouncement;
                             string announcementSubs = customSquad.EntranceAnnouncementSubs;
@@ -121,8 +122,7 @@ namespace Omni_Utils.EventHandlers
                 case Faction.FoundationStaff:
                     {
                         customSquad = OmniUtilsPlugin.NextWaveMtf;
-                        //NamingRulesManager.TryGetNamingRule(Team.FoundationForces, out UnitNamingRule rule);
-                        
+
                         if (customSquad is null)
                         {
                             return;
@@ -155,7 +155,7 @@ namespace Omni_Utils.EventHandlers
                                 string announcement = customSquad.EntranceAnnouncement;
                                 string announcementSubs = customSquad.EntranceAnnouncementSubs;
 
-                                announcement = announcement.Replace("%division%", MakeUnitNameReadable(NamingRulesManager.GeneratedNames[Team.FoundationForces].LastOrDefault()));
+                                announcement = announcement.Replace("%division%", OmniUtilsAPI.MakeUnitNameReadable(NamingRulesManager.GeneratedNames[Team.FoundationForces].LastOrDefault()));
                                 announcementSubs = announcementSubs.Replace("%division%", NamingRulesManager.GeneratedNames[Team.FoundationForces].LastOrDefault());
                                 Cassie.MessageTranslated(announcement, announcementSubs);
                             });
@@ -165,13 +165,7 @@ namespace Omni_Utils.EventHandlers
                 default:
                     return;
             }
-        }
-        public string MakeUnitNameReadable(string unit)
-        {
-            string output = string.Empty; //output = ""
-            string[] thing = unit.Split('-'); //thing = ["HOTEL", "09"]
-            output += $"nato_{unit[0]} {thing[1]}"; //output = "nato_H 09"
-            return output;
+
         }
     }
 }

--- a/Omni-Utils/EventHandlers/PluginEventHandler.cs
+++ b/Omni-Utils/EventHandlers/PluginEventHandler.cs
@@ -15,6 +15,7 @@ using UnityEngine;
 using Display = RueI.Displays.Display;
 using Random = UnityEngine.Random;
 using Config = Omni_Utils.Configs.Config;
+using Omni_Utils.API;
 
 namespace Omni_Utils.EventHandlers
 {
@@ -162,8 +163,8 @@ namespace Omni_Utils.EventHandlers
                         OmniUtilsPlugin.pluginInstance.Config.CustomTerminationAnnouncementConfig.ScpCassieString.TryGetValue(newType, out subjectName);
                     }
                 }
-                
-                Cassie.MessageTranslated($"{subjectName.Words} terminated . termination cause unspecified",$"{subjectName.Translation} terminated. Termination cause unspecified.");
+                CustomAnnouncement fallback = config.CustomTerminationAnnouncementConfig.FallbackTerminationAnnouncement;
+                Cassie.MessageTranslated(fallback.Words.Replace("%subject%", subjectName.Words), fallback.Translation.Replace("%subject%", subjectName.Translation));
                 return;
             }
 
@@ -202,6 +203,16 @@ namespace Omni_Utils.EventHandlers
             }
             cassie = cassie.Replace("%subject%", subjectName.Words);
             subs = subs.Replace("%subject%", subjectName.Translation);
+            if (attacker.UnitName.Length < 0)
+            {
+                cassie = cassie.Replace("%division%", OmniUtilsAPI.MakeUnitNameReadable(attacker.UnitName));
+                subs = subs.Replace("%division%", attacker.UnitName);
+            }
+            else
+            {
+                cassie = cassie.Replace("%division%", "unknown");
+                subs = subs.Replace("%division%", "UNKNOWN");
+            }
             Cassie.MessageTranslated(cassie, subs);
         }
         public void OnPlayerDeath(DyingEventArgs e)

--- a/Omni-Utils/EventHandlers/PluginEventHandler.cs
+++ b/Omni-Utils/EventHandlers/PluginEventHandler.cs
@@ -46,7 +46,7 @@ namespace Omni_Utils.EventHandlers
         }
         public void OnChangingNickname(ChangingNicknameEventArgs e)
         {
-            e.NewName = PlayerExtensions.ProcessNickname(e.NewName, e.Player);
+            if(e.NewName is not null) e.NewName = PlayerExtensions.ProcessNickname(e.NewName, e.Player);
             if (config.RolenameConfig.IsEnabled) Timing.CallDelayed(0.1f, () => e.Player.SetPlayerCustomInfoAndRoleName(e.Player.GetCustomInfo(), e.Player.GetRoleName()));
         }
         public void OnChangingRole(ChangingRoleEventArgs e)
@@ -203,7 +203,8 @@ namespace Omni_Utils.EventHandlers
             }
             cassie = cassie.Replace("%subject%", subjectName.Words);
             subs = subs.Replace("%subject%", subjectName.Translation);
-            if (attacker.UnitName.Length < 0)
+            //make sure unit name is not empty
+            if (attacker.UnitName is not null)
             {
                 cassie = cassie.Replace("%division%", OmniUtilsAPI.MakeUnitNameReadable(attacker.UnitName));
                 subs = subs.Replace("%division%", attacker.UnitName);

--- a/Omni-Utils/OmniUtilsPlugin.cs
+++ b/Omni-Utils/OmniUtilsPlugin.cs
@@ -30,7 +30,7 @@ namespace Omni_Utils
 
         public override string Prefix => "omni-utils";
 
-        public override Version Version => new(1,0,0);
+        public override Version Version => new(1,0,1);
 
 
 

--- a/OmniCommonLibrary/OmniCommonLibrary.cs
+++ b/OmniCommonLibrary/OmniCommonLibrary.cs
@@ -15,7 +15,7 @@ namespace OmniCommonLibrary
         public override string Author => "icedchqi";
         public override string Name => "Omni-2 Library";
         public override string Prefix => "omni-commonlibrary";
-        public override Version Version => new Version(1, 0, 0);
+        public override Version Version => new Version(1, 0, 1);
         public static OmniCommonLibrary pluginInstance = null;
         //I call these 'ranks' because they stay the same per-life, and all use the same data slot on a player.
         public static List<RankGroup> consistentReplacements = new List<RankGroup>();

--- a/OmniCommonLibrary/OmniCommonLibrary.cs
+++ b/OmniCommonLibrary/OmniCommonLibrary.cs
@@ -13,7 +13,7 @@ namespace OmniCommonLibrary
     public class OmniCommonLibrary : Plugin<Config>
     {
         public override string Author => "icedchqi";
-        public override string Name => "Omni Library";
+        public override string Name => "Omni-2 Library";
         public override string Prefix => "omni-commonlibrary";
         public override Version Version => new Version(1, 0, 0);
         public static OmniCommonLibrary pluginInstance = null;


### PR DESCRIPTION
Update 1.0.1
Utils:
- Added %division% argument to termination announcement config, which is replaced with the killer's UnitName (eg: BRAVO-02, WHISKEY-17). Defaults to UNKNOWN if the killer doesn't have a UnitName.
- Updated rolename command to change the output text to "Added rolename {name} to {list.Count()} players.".

CommonLibrary:
- Fixed NREs related to PlayerExtensions.HasOverallRole